### PR TITLE
Add quote= argument to read.table call to load kraken data

### DIFF
--- a/amrplusplus-shiny/dataIO.R
+++ b/amrplusplus-shiny/dataIO.R
@@ -47,7 +47,7 @@ load_amr_annotations <- function(annotations_filepath) {
 load_kraken_data <- function(kraken_filepath) {
     out <- tryCatch(
         {
-            temp_kraken <- read.table(kraken_filepath, header=T, row.names=1, sep=',')
+            temp_kraken <- read.table(kraken_filepath, header=T, row.names=1, sep=',', quote="")
             kraken <- newMRexperiment(temp_kraken[rowSums(temp_kraken) > 0, ])
         },
         error=function(e) {


### PR DESCRIPTION
Hello. Thanks for the excellent work with AMR ++ Shiny! I have a suggestion for the `read.table` call to load  Kraken data into the app. I think it would be important to use the `quote` argument inside this function and set it to either `quote = ""`, or `quote="\""`. The reason for this is that the default in `read.table` is `quote = "\"'"`, which reads the apostrophe/single quote character as a quoting character. The problem with this is that there are some species names that contain an apostrophe character. In one extreme case in working with the app, this lead to `read.table` to skip up to ~ two thousand rows from the Kraken analytic matrix. Those were the rows between two other rows that had species with apostrophe/single quote characters in their name. Thanks again for the awesome app!